### PR TITLE
style: unify favicon and logo with canonical STOA design

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -36,6 +36,8 @@ sites:
 status-website:
   cname: status.gostoa.dev
   logoUrl: https://raw.githubusercontent.com/stoa-platform/status/master/assets/stoa-logo.svg
+  favicon: https://raw.githubusercontent.com/stoa-platform/status/master/assets/stoa-icon.svg
+  faviconSvg: https://raw.githubusercontent.com/stoa-platform/status/master/assets/stoa-icon.svg
   name: STOA Platform Status
   introTitle: "**STOA Platform** is the European Agent Gateway — AI-native API management, open source."
   introMessage: >

--- a/assets/stoa-icon.svg
+++ b/assets/stoa-icon.svg
@@ -1,4 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <rect width="32" height="32" rx="6" fill="#1a1a2e"/>
-  <text x="16" y="22" font-family="system-ui, sans-serif" font-size="16" font-weight="bold" fill="#e94560" text-anchor="middle">S</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="stoaGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#047857"/>
+      <stop offset="100%" style="stop-color:#059669"/>
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="16" cy="16" r="15" fill="url(#stoaGradient)"/>
+  <!-- S letter stylized as API flow -->
+  <path d="M10 11 Q10 8, 16 8 Q22 8, 22 11 Q22 14, 16 14 Q10 14, 10 17 Q10 20, 16 20 Q22 20, 22 24 Q22 27, 16 27"
+        stroke="white"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        fill="none"/>
+  <!-- API dots -->
+  <circle cx="8" cy="14" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="24" cy="14" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="8" cy="20" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="24" cy="20" r="1.5" fill="white" opacity="0.8"/>
 </svg>

--- a/assets/stoa-logo.svg
+++ b/assets/stoa-logo.svg
@@ -1,5 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 40" fill="none">
-  <rect width="40" height="40" rx="8" fill="#1a1a2e"/>
-  <text x="20" y="28" font-family="system-ui, sans-serif" font-size="20" font-weight="bold" fill="#e94560" text-anchor="middle">S</text>
-  <text x="52" y="28" font-family="system-ui, sans-serif" font-size="22" font-weight="bold" fill="#1a1a2e">STOA</text>
+  <defs>
+    <linearGradient id="stoaGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#047857"/>
+      <stop offset="100%" style="stop-color:#059669"/>
+    </linearGradient>
+  </defs>
+  <!-- Icon -->
+  <circle cx="20" cy="20" r="18" fill="url(#stoaGradient)"/>
+  <path d="M12 15 Q12 12, 20 12 Q28 12, 28 15 Q28 18, 20 18 Q12 18, 12 21 Q12 24, 20 24 Q28 24, 28 28 Q28 31, 20 31"
+        stroke="white" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+  <circle cx="9" cy="18" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="31" cy="18" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="9" cy="24" r="1.5" fill="white" opacity="0.8"/>
+  <circle cx="31" cy="24" r="1.5" fill="white" opacity="0.8"/>
+  <!-- Text -->
+  <text x="52" y="28" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="bold" fill="#047857">STOA</text>
 </svg>


### PR DESCRIPTION
## Summary
- Replace dark rectangle + red "S" icon with canonical STOA green circle favicon
- Replace dark logo with green-branded STOA logo (matching all other endpoints)
- Add `favicon` + `faviconSvg` config to Upptime status-website section

## Before
- Icon: Dark navy rectangle with red "S" letter
- Logo: Same dark style + "STOA" text

## After
- Icon: Green gradient circle with white "S" + API dots (canonical STOA design)
- Logo: Same green circle + "STOA" in brand green

## Part of cross-repo favicon unification
All 4 repos now use the same favicon:
- stoa [PR #572](https://github.com/stoa-platform/stoa/pull/572) ✅ merged
- stoa-web [PR #8](https://github.com/stoa-platform/stoa-web/pull/8) ✅ merged
- stoa-docs [PR #51](https://github.com/stoa-platform/stoa-docs/pull/51) ✅ merged
- **status** (this PR)

## Test plan
- [ ] status.gostoa.dev shows green circle favicon after Upptime rebuild
- [ ] Logo on status page uses green branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)